### PR TITLE
Keep track of raffle participants and movies

### DIFF
--- a/lib/movies/movies.ts
+++ b/lib/movies/movies.ts
@@ -278,6 +278,21 @@ export async function chooseMovieOfTheWeek() {
 
   await updateChosenMovie(movieObject!, chosen!.user.id);
 
+  const raffle = await prisma.raffle.create({
+    data: {
+      participants: {
+        connect: shortlists.map((shortlist) => ({ id: shortlist.user.id })),
+      },
+      movies: {
+        connect: movies.map((movie) => ({ id: movie.movie.id })),
+      },
+      winningMovieID: chosen?.movie.id!,
+      date: formatISO(new Date(), {
+        representation: "date",
+      }),
+    },
+  });
+
   for (let item of shortlists) {
     await updateShortlistState(false, item.id);
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -75,6 +75,8 @@ model Movie {
   ratings           Rating[]
   reviews           Review[]
   userId            String?     @db.ObjectId
+  raffles           Raffle[]    @relation(fields: [raffleIDs], references: [id])
+  raffleIDs         String[]    @db.ObjectId
 
   @@map("movies")
 }
@@ -124,6 +126,18 @@ model User {
   ratings       Rating[]
   reviews       Review[]
   movies        Movie[]
+  Raffle        Raffle[]    @relation(fields: [raffleIDs], references: [id])
+  raffleIDs     String[]    @db.ObjectId
 
   @@map("users")
+}
+
+model Raffle {
+  id             String   @id @default(auto()) @map("_id") @db.ObjectId
+  participants   User[]   @relation(fields: [participantIDs], references: [id])
+  participantIDs String[] @db.ObjectId
+  movieIDs       String[] @db.ObjectId
+  movies         Movie[]  @relation(fields: [movieIDs], references: [id])
+  winningMovieID String   @db.ObjectId
+  date           String
 }


### PR DESCRIPTION
Expands schema, allowing to store and keep track of raffle participants, the movies participating in the raffle, the winner and date. Should allow for interesting data visualisation in the future.