### PR TITLE
Update user avatar on login if it has changed

### DIFF
--- a/app/(landing)/login/discord/callback/route.ts
+++ b/app/(landing)/login/discord/callback/route.ts
@@ -72,6 +72,17 @@ export async function GET(request: Request): Promise<Response> {
 	});
 
 	if (existingUser !== null) {
+		const discordAvatar = `https://cdn.discordapp.com/avatars/${discordUser.id}/${discordUser.avatar}.png`;
+		if (existingUser?.user?.image !== discordAvatar) {
+			await db?.user.update({
+				where: {
+					id: existingUser.userId,
+				},
+				data: {
+					image: discordAvatar,
+				},
+			});
+		}
 		const sessionToken = generateSessionToken();
 		const session = await createSession(sessionToken, existingUser.userId);
 		setSessionTokenCookie(sessionToken, session.expiresAt);


### PR DESCRIPTION
The user avatar was pulled from discord upon them registering an account for the first time. If it changed, it was never updated. This checks the avatar striing upon login and updates it if it has changed.

Taking into account the frequency with which users change their avatars, this is most likely sufficient for the time being