### PR TITLE
21 extend sonnertoaster

### DIFF
--- a/app/(home)/layout.tsx
+++ b/app/(home)/layout.tsx
@@ -8,7 +8,6 @@ import { SocketClient } from "components/common/SocketClient";
 import NavbarWrapper from "components/nav/NavbarWrapper";
 import ReplaceDialog from "components/search/ReplaceDialog";
 import { Suspense } from "react";
-import { Toaster } from "sonner";
 
 export default async function HomeLayout({
 	searchModal,
@@ -32,8 +31,6 @@ export default async function HomeLayout({
 					<NavbarWrapper />
 				</Suspense>
 				<SocketClient />
-
-				<Toaster position="top-center" />
 				<ReplaceDialog />
 				{searchModal}
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -47,7 +47,7 @@
 	--muted: oklch(0.97 0.0013 286.38);
 	--muted-foreground: oklch(0.44 0.011 285.94);
 	--accent: oklch(0.67 0.0952 196.72);
-	--accent-foreground: oklch(1 0 0);
+	--accent-foreground: oklch(0 0 none);
 	--destructive: oklch(0.64 0.2078 25.33);
 	--destructive-foreground: oklch(0.98 0 0);
 	--border: oklch(0.4 0.0178 285.57);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,4 @@
+import { Toaster } from "@/components/ui/Toaster";
 import Providers from "@/utils/provider";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Inter } from "next/font/google";
@@ -25,6 +26,7 @@ export default async function RootLayout({
 				<Providers>
 					{children}
 					<SpeedInsights />
+					<Toaster position="bottom-center" closeButton />
 				</Providers>
 				{/*<script dangerouslySetInnerHTML={{ __html: getTheme }} /> */}
 				{/*<script dangerouslySetInnerHTML={{ __html: getAccent }} />*/}

--- a/components/search/SearchSidebarContent.tsx
+++ b/components/search/SearchSidebarContent.tsx
@@ -5,21 +5,20 @@ import Providers from "@/components/search/Providers";
 import SearchInput from "@/components/search/SearchInput";
 import VoteRange from "@/components/search/VoteRange";
 import ShortlistSidebarContent from "@/components/shortlist/ShortlistSidebarContent";
-import { TabsContent } from "@/components/ui/Tabs";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/Tabs";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/Tabs";
 export default function SearchSidebarContent() {
 	return (
 		<Tabs defaultValue="discover" className="flex flex-col gap-4 w-full h-full">
 			<TabsList className="grid w-full grid-cols-2 bg-transparent gap-1 px-2">
 				<TabsTrigger
 					value="discover"
-					className="bg-transparent border border-t-0 border-r-0 border-l-0 rounded-tr-none rounded-tl-none bg-card data-[state=active]:bg-accent/50 text-accent-foreground"
+					className="border border-t-0 border-r-0 border-l-0 rounded-tr-none rounded-tl-none bg-card data-[state=active]:bg-accent/50 text-accent-foreground"
 				>
 					Discover
 				</TabsTrigger>
 				<TabsTrigger
 					value="shortlist"
-					className="bg-transparent border border-t-0 border-r-0 border-l-0 rounded-tr-none rounded-tl-none bg-card data-[state=active]:bg-accent/50 text-accent-foreground"
+					className="border border-t-0 border-r-0 border-l-0 rounded-tr-none rounded-tl-none bg-card data-[state=active]:bg-accent/50 text-accent-foreground"
 				>
 					Shortlist
 				</TabsTrigger>

--- a/components/ui/Toaster.tsx
+++ b/components/ui/Toaster.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { Toaster as Sonner } from "sonner"
+
+type ToasterProps = React.ComponentProps<typeof Sonner>
+
+const Toaster = ({ ...props }: ToasterProps) => {
+    const { theme = "system" } = useTheme()
+
+    return (
+        <Sonner
+            theme={theme as ToasterProps["theme"]}
+            className="toaster group"
+            toastOptions={{
+                classNames: {
+                    toast:
+                        "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
+                    description: "group-[.toast]:text-muted-foreground",
+                    actionButton:
+                        "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
+                    cancelButton:
+                        "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
+                },
+            }}
+            {...props}
+        />
+    )
+}
+
+export { Toaster }


### PR DESCRIPTION
Adds a baseline extendable toast component, replacing just using the toast from Sonner.

See [Link](https://ui.shadcn.com/docs/components/sonner)

Further modifications are to be expected in the future, such as a countdown timer and the possibility to add more complex content or actions into the toast.